### PR TITLE
add JS logic toggle the color scheme

### DIFF
--- a/src/wp-a11y-day/functions.php
+++ b/src/wp-a11y-day/functions.php
@@ -275,17 +275,20 @@ add_action( 'after_setup_theme', 'wp_accessibility_day_content_width', 0 );
  * Enqueue scripts and styles.
  */
 function wp_accessibility_day_scripts() {
-	$style_ver = gmdate( 'ymd-Gis', filemtime( get_stylesheet_directory() . '/style.css' ) );
-	$gform_ver = gmdate( 'ymd-Gis', filemtime( get_stylesheet_directory() . '/css/gforms.css' ) );
-	$event_ver = gmdate( 'ymd-Gis', filemtime( get_stylesheet_directory() . '/css/event.css' ) );
-	$js_ver    = gmdate( 'ymd-Gis', filemtime( get_stylesheet_directory() . '/js/navigation.js' ) );
-	$ts_ver    = gmdate( 'ymd-Gis', filemtime( get_stylesheet_directory() . '/js/talk-time.js' ) );
+	$style_ver      = gmdate( 'ymd-Gis', filemtime( get_stylesheet_directory() . '/style.css' ) );
+	$dark_style_ver = gmdate( 'ymd-Gis', filemtime( get_stylesheet_directory() . '/css/dark-mode.css' ) );
+	$gform_ver      = gmdate( 'ymd-Gis', filemtime( get_stylesheet_directory() . '/css/gforms.css' ) );
+	$event_ver      = gmdate( 'ymd-Gis', filemtime( get_stylesheet_directory() . '/css/event.css' ) );
+	$js_ver         = gmdate( 'ymd-Gis', filemtime( get_stylesheet_directory() . '/js/navigation.js' ) );
+	$ts_ver         = gmdate( 'ymd-Gis', filemtime( get_stylesheet_directory() . '/js/talk-time.js' ) );
+	$cs_ver         = gmdate( 'ymd-Gis', filemtime( get_stylesheet_directory() . '/js/color-scheme.js' ) );
 
 	wp_enqueue_style( 'wp-accessibility-day-style', get_stylesheet_uri(), array(), $style_ver );
 	wp_enqueue_style( 'wp-accessibility-day-gforms', get_template_directory_uri() . '/css/gforms.css', array(), $gform_ver );
 	wp_enqueue_style( 'wp-accessibility-day-event', get_template_directory_uri() . '/css/event.css', array(), $event_ver );
 	wp_enqueue_script( 'wp-accessibility-day-navigation', get_template_directory_uri() . '/js/navigation.js', array(), $js_ver, true );
 	wp_enqueue_script( 'wp-accessibility-day-time', get_template_directory_uri() . '/js/talk-time.js', array(), $ts_ver, true );
+	wp_enqueue_script( 'wp-accessibility-color-scheme', get_template_directory_uri() . '/js/color-scheme.js', array(), $cs_ver, true );
 	$start = strtotime( get_option( 'wpad_start_time' ) );
 	$end   = strtotime( get_option( 'wpad_end_time' ) );
 	$args = array(
@@ -296,6 +299,11 @@ function wp_accessibility_day_scripts() {
 		'end'          => gmdate( 'Y-m-d', $end ) . 'T',
 	);
 	wp_localize_script( 'wp-accessibility-day-time', 'tz', $args );
+
+	$args = array(
+		'darkstylesheet' => get_template_directory_uri() . '/css/dark-mode.css?v=' . $dark_style_ver,
+	);
+	wp_localize_script( 'wp-accessibility-color-scheme', 'wpA11YdayColorScheme', $args );
 
 	if ( is_singular() && comments_open() && get_option( 'thread_comments' ) ) {
 		wp_enqueue_script( 'comment-reply' );

--- a/src/wp-a11y-day/header.php
+++ b/src/wp-a11y-day/header.php
@@ -49,7 +49,12 @@
 					?>
 				</nav><!-- #utility-navigation -->
 				<div class="utility-dark-mode placeholder">
-					<button type="button" aria-pressed="true" aria-label="Light mode"><span class="fa-regular fa-sun" aria-hidden="true"></span></button><button type="button" aria-pressed="false" aria-label="Dark mode"><span class="fa-solid fa-moon" aria-hidden="true"></span></button>
+					<button type="button" aria-pressed="true" aria-label="Enable light mode">
+						<span class="fa-regular fa-sun" aria-hidden="true"></span>
+					</button>
+					<button type="button" aria-pressed="false" aria-label="Enable dark mode">
+						<span class="fa-solid fa-moon" aria-hidden="true"></span>
+					</button>
 				</div>
 			</div>
 			<nav id="main-navigation" class="main-navigation navigation" aria-label="Main">

--- a/src/wp-a11y-day/js/color-scheme.js
+++ b/src/wp-a11y-day/js/color-scheme.js
@@ -1,0 +1,87 @@
+/**
+ * Handle dark/light toggle.
+ */
+/* global wpA11YdayColorScheme */
+
+document.addEventListener( 'DOMContentLoaded', () => {
+	const prefersDarkScheme = window.matchMedia("(prefers-color-scheme: dark)").matches;
+	const lightModeButton = document.querySelector('button[aria-label="Enable light mode"]');
+	const darkModeButton = document.querySelector('button[aria-label="Enable dark mode"]');
+	const colorSchemeCookieName = 'wpadColorScheme';
+	const themeStyleSheet = document.getElementById('wp-accessibility-day-style-css');
+	const head = themeStyleSheet.parentNode;
+	const darkModeStyleSheet = document.createElement('link');
+
+
+	darkModeStyleSheet.setAttribute('rel', 'stylesheet');
+	darkModeStyleSheet.setAttribute('id', 'wp-accessibility-day-dark-css-toggle');
+	darkModeStyleSheet.setAttribute('href', wpA11YdayColorScheme.darkstylesheet );
+	darkModeStyleSheet.setAttribute('type', 'text/css');
+	darkModeStyleSheet.setAttribute('media', 'all');
+
+	/**
+	 * Get the value of a cookie
+	 * Source: https://gist.github.com/wpsmith/6cf23551dd140fb72ae7
+	 * @param  {String} name  The name of the cookie
+	 * @return {String}       The cookie value
+	 */
+	const getCookie = (name) => {
+		let value = `; ${document.cookie}`;
+		let parts = value.split(`; ${name}=`);
+		if (parts.length === 2) return parts.pop().split(';').shift();
+	}
+
+	/**
+	 * Set a cookie with default length of one year.
+	 *
+	 * @param {String} name 
+	 * @param {String} value 
+	 * @param {Number} days 
+	 */
+	const setCookie = (name, value, days = 365) => {
+		document.cookie = `${name}=${value}; path=/; max-age=${60 * 60 * 24 * days};`;
+	}
+
+	const toggleButton = (active, inactive) => {
+		active.setAttribute('aria-pressed', 'true');
+		inactive.setAttribute('aria-pressed', 'false');
+	}
+
+	const toggleStyle = (action = 'add') => {
+		switch (action) {
+			case 'remove':
+				head.removeChild(darkModeStyleSheet);
+			break;
+			default:
+				head.insertBefore(darkModeStyleSheet, themeStyleSheet.nextSibling)
+		}
+	}
+
+	const colorschemeCookie = getCookie(colorSchemeCookieName);
+
+	// Update the active state.
+	if ('dark' === colorschemeCookie || (! colorschemeCookie && prefersDarkScheme)) {
+		toggleButton(darkModeButton, lightModeButton);
+		toggleStyle();
+	}
+
+	lightModeButton.addEventListener('click', (e) => {
+		e.preventDefault();
+
+		if ('false' === lightModeButton.getAttribute('aria-pressed')) {
+			toggleButton(lightModeButton, darkModeButton);
+			toggleStyle('remove');
+			setCookie(colorSchemeCookieName, 'light');
+		}
+	});
+
+	darkModeButton.addEventListener('click', (e) => {
+		e.preventDefault();
+
+		if ('false' === darkModeButton.getAttribute('aria-pressed')) {
+			toggleButton(darkModeButton, lightModeButton);
+			toggleStyle();
+			setCookie(colorSchemeCookieName, 'dark');
+		}
+	});
+});


### PR DESCRIPTION
fixes #20 

Adds a new JS file that handles loading the dark mode stylesheet. 

- If no cookie present and prefers-color-scheme dark is true, dark mode stylesheet is loaded and button is toggled to show dark mode enabled
- If no cookie present and not prefers-color-scheme page loads as normal for light mode
- If cookie present and cookie is "dark" the dark mode stylesheet is loaded and button is toggled
- If cookie is present and "light" then no change is made even if prefers-color-scheme dark is true because the user opted to light mode

Adds event listener for the button clicks that sets the cookie and toggles the mode for the button clicked.