### PR TITLE
add high contrast modes

### DIFF
--- a/src/wp-a11y-day/css/dark-mode.css
+++ b/src/wp-a11y-day/css/dark-mode.css
@@ -3,7 +3,7 @@
 --------------------------------------------------------------*/
 
 body {
-  --bg: #333;
+	--bg: #333;
 	--fg: var(--white);
 	--accent1: var(--lightest-blue);
 	--accent1s1: var(--light-blue);

--- a/src/wp-a11y-day/css/high-contrast-dark.css
+++ b/src/wp-a11y-day/css/high-contrast-dark.css
@@ -1,0 +1,22 @@
+/*--------------------------------------------------------------
+# High Contrast Dark (Light Mode Inverted Colors)
+--------------------------------------------------------------*/
+
+body {
+	--bg: Black;
+	--fg: White;
+	--accent1: DarkBlue;
+	--accent1s1: Blue;
+	--accent1s2: Aqua;
+	--accent2: Green;
+	--accent2s1: LimeGreen;
+	--accent3: Orange;
+	--accent3s1: Gold;
+	--accent4: Yellow;
+	--accent4s1: LightYellow;
+	--accent5: Coral;
+	--accent6: Magenta;
+	--s1: #333;
+	--s2: #666;
+	--s3: #ccc;
+}

--- a/src/wp-a11y-day/css/high-contrast.css
+++ b/src/wp-a11y-day/css/high-contrast.css
@@ -1,0 +1,22 @@
+/*--------------------------------------------------------------
+# High Contrast (Dark Mode Inverted Colors)
+--------------------------------------------------------------*/
+
+body {
+	--bg: White;
+	--fg: Black;
+	--accent1: Aqua;
+	--accent1s1: Blue;
+	--accent1s2: DarkBlue;
+	--accent2: LimeGreen;
+	--accent2s1: Green;
+	--accent3: Gold;
+	--accent3s1: DarkOrange;
+	--accent4: LightYellow;
+	--accent4s1: Yellow;
+	--accent5: Magenta;
+	--accent6: Coral;
+	--s1: #ccc;
+	--s2: #666;
+	--s3: #333;
+}

--- a/src/wp-a11y-day/functions.php
+++ b/src/wp-a11y-day/functions.php
@@ -277,6 +277,8 @@ add_action( 'after_setup_theme', 'wp_accessibility_day_content_width', 0 );
 function wp_accessibility_day_scripts() {
 	$style_ver      = gmdate( 'ymd-Gis', filemtime( get_stylesheet_directory() . '/style.css' ) );
 	$dark_style_ver = gmdate( 'ymd-Gis', filemtime( get_stylesheet_directory() . '/css/dark-mode.css' ) );
+	$hc_ver         = gmdate( 'ymd-Gis', filemtime( get_stylesheet_directory() . '/css/high-contrast.css' ) );
+	$hc_dark_ver    = gmdate( 'ymd-Gis', filemtime( get_stylesheet_directory() . '/css/high-contrast-dark.css' ) );
 	$gform_ver      = gmdate( 'ymd-Gis', filemtime( get_stylesheet_directory() . '/css/gforms.css' ) );
 	$event_ver      = gmdate( 'ymd-Gis', filemtime( get_stylesheet_directory() . '/css/event.css' ) );
 	$js_ver         = gmdate( 'ymd-Gis', filemtime( get_stylesheet_directory() . '/js/navigation.js' ) );
@@ -301,7 +303,9 @@ function wp_accessibility_day_scripts() {
 	wp_localize_script( 'wp-accessibility-day-time', 'tz', $args );
 
 	$args = array(
-		'darkstylesheet' => get_template_directory_uri() . '/css/dark-mode.css?v=' . $dark_style_ver,
+		'darkstylesheet'   => get_template_directory_uri() . '/css/dark-mode.css?v=' . $dark_style_ver,
+		'hcstylesheet'     => get_template_directory_uri() . '/css/high-contrast.css?v=' . $hc_ver,
+		'hcdarkstylesheet' => get_template_directory_uri() . '/css/high-contrast-dark.css?v=' . $hc_dark_ver,
 	);
 	wp_localize_script( 'wp-accessibility-color-scheme', 'wpA11YdayColorScheme', $args );
 

--- a/src/wp-a11y-day/js/color-scheme.js
+++ b/src/wp-a11y-day/js/color-scheme.js
@@ -11,6 +11,7 @@ document.addEventListener( 'DOMContentLoaded', () => {
 	const themeStyleSheet = document.getElementById('wp-accessibility-day-style-css');
 	const head = themeStyleSheet.parentNode;
 	const darkModeStyleSheet = document.createElement('link');
+	const highContrastStyleSheet = document.createElement('link');
 
 
 	darkModeStyleSheet.setAttribute('rel', 'stylesheet');
@@ -18,6 +19,12 @@ document.addEventListener( 'DOMContentLoaded', () => {
 	darkModeStyleSheet.setAttribute('href', wpA11YdayColorScheme.darkstylesheet );
 	darkModeStyleSheet.setAttribute('type', 'text/css');
 	darkModeStyleSheet.setAttribute('media', 'all');
+
+	highContrastStyleSheet.setAttribute('rel', 'stylesheet');
+	highContrastStyleSheet.setAttribute('id', 'wp-accessibility-day-dark-css-toggle');
+	highContrastStyleSheet.setAttribute('href', wpA11YdayColorScheme.hcstylesheet );
+	highContrastStyleSheet.setAttribute('type', 'text/css');
+	highContrastStyleSheet.setAttribute('media', 'all');
 
 	/**
 	 * Get the value of a cookie
@@ -42,11 +49,43 @@ document.addEventListener( 'DOMContentLoaded', () => {
 		document.cookie = `${name}=${value}; path=/; max-age=${60 * 60 * 24 * days};`;
 	}
 
+	/**
+	 * Toggles the active/pressed state of the buttons.
+	 *
+	 * @param {HTMLElement} active 
+	 * @param {HTMLElement} inactive 
+	 */
 	const toggleButton = (active, inactive) => {
 		active.setAttribute('aria-pressed', 'true');
 		inactive.setAttribute('aria-pressed', 'false');
 	}
 
+	/**
+	 * Checks if the user is has Inverted Colors on.
+	 *
+	 * @returns {Boolean}
+	 */
+	const isUsingMacInvertedColors = () => {
+		const mediaQueryList = window.matchMedia('(inverted-colors: inverted)');
+		return mediaQueryList.matches;
+	}
+
+	/**
+	 * Checks if the user requested high contrast.
+	 *
+	 * @returns {Boolean}
+	 */
+	const isHighContrast = () => {
+		const mediaQueryList = matchMedia('(forced-colors: active)');
+		const prefersContrast = matchMedia("(prefers-contrast: more)");
+		return mediaQueryList.matches || prefersContrast.matches;
+	}
+
+	/**
+	 * Switches the stylesheet.
+	 *
+	 * @param {String} action 
+	 */
 	const toggleStyle = (action = 'add') => {
 		switch (action) {
 			case 'remove':
@@ -63,6 +102,11 @@ document.addEventListener( 'DOMContentLoaded', () => {
 	if ('dark' === colorschemeCookie || (! colorschemeCookie && prefersDarkScheme)) {
 		toggleButton(darkModeButton, lightModeButton);
 		toggleStyle();
+		highContrastStyleSheet.setAttribute('href', isUsingMacInvertedColors ? wpA11YdayColorScheme.hcstylesheet : wpA11YdayColorScheme.hcdarkstylesheet );
+	}
+
+	if (isUsingMacInvertedColors() || isHighContrast()) {
+		head.appendChild(highContrastStyleSheet);
 	}
 
 	lightModeButton.addEventListener('click', (e) => {
@@ -72,6 +116,7 @@ document.addEventListener( 'DOMContentLoaded', () => {
 			toggleButton(lightModeButton, darkModeButton);
 			toggleStyle('remove');
 			setCookie(colorSchemeCookieName, 'light');
+			highContrastStyleSheet.setAttribute('href', isUsingMacInvertedColors ? wpA11YdayColorScheme.hcdarkstylesheet : wpA11YdayColorScheme.hcstylesheet );
 		}
 	});
 
@@ -82,6 +127,7 @@ document.addEventListener( 'DOMContentLoaded', () => {
 			toggleButton(darkModeButton, lightModeButton);
 			toggleStyle();
 			setCookie(colorSchemeCookieName, 'dark');
+			highContrastStyleSheet.setAttribute('href', isUsingMacInvertedColors ? wpA11YdayColorScheme.hcstylesheet : wpA11YdayColorScheme.hcdarkstylesheet );
 		}
 	});
 });


### PR DESCRIPTION
Adds two new stylesheets for high contrast and high contrast dark. The placeholder colors are not final and will need work to set and verify the contrast requirements but the stylesheets should conform to the limited stylesheet generated with forced-colors to ensure max compatibility.