### PR TITLE
add arrow button style

### DIFF
--- a/src/wp-a11y-day/functions.php
+++ b/src/wp-a11y-day/functions.php
@@ -268,6 +268,22 @@ function wp_accessibility_day_widgets_init() {
 add_action( 'widgets_init', 'wp_accessibility_day_widgets_init' );
 
 /**
+ * Register block styles.
+ *
+ * @return void
+ */
+function wp_accessibility_day_block_styles() {
+    register_block_style(
+        'core/button', // name of your block
+        array(
+            'name'  => 'arrow', // part of the class that gets added to the block.
+            'label' => __( 'Arrow Block', 'wp-accessibility-day' ),
+        )
+    );
+}
+add_action( 'init', 'wp_accessibility_day_block_styles' );
+
+/**
  * Set the content width in pixels, based on the theme's design and stylesheet.
  *
  * Priority 0 to make it available to lower priority callbacks.

--- a/src/wp-a11y-day/functions.php
+++ b/src/wp-a11y-day/functions.php
@@ -268,22 +268,6 @@ function wp_accessibility_day_widgets_init() {
 add_action( 'widgets_init', 'wp_accessibility_day_widgets_init' );
 
 /**
- * Register block styles.
- *
- * @return void
- */
-function wp_accessibility_day_block_styles() {
-    register_block_style(
-        'core/button', // name of your block
-        array(
-            'name'  => 'arrow', // part of the class that gets added to the block.
-            'label' => __( 'Arrow Block', 'wp-accessibility-day' ),
-        )
-    );
-}
-add_action( 'init', 'wp_accessibility_day_block_styles' );
-
-/**
  * Set the content width in pixels, based on the theme's design and stylesheet.
  *
  * Priority 0 to make it available to lower priority callbacks.

--- a/src/wp-a11y-day/js/blocks.js
+++ b/src/wp-a11y-day/js/blocks.js
@@ -13,4 +13,9 @@ wp.domReady( () => {
       name: "button-underline",
       label: "Underline"
     });
+
+    wp.blocks.registerBlockStyle("core/button", {
+      name: "arrow",
+      label: "Arrow"
+    });
 } );

--- a/src/wp-a11y-day/style.css
+++ b/src/wp-a11y-day/style.css
@@ -539,7 +539,7 @@ table {
 	border-bottom: none;
 }
 
-.wp-block-button:not(.is-style-button-underline) a,
+.wp-block-button:not(.is-style-button-underline, .is-style-arrow) a,
 button,input[type="button"],input[type="reset"],input[type="submit"] {
 	border:1px solid;
 	border-radius:3px;
@@ -550,7 +550,7 @@ button,input[type="button"],input[type="reset"],input[type="submit"] {
 	display: inline-block;
 }
 
-.wp-block-button:not(.is-style-button-underline) a:hover, .wp-block-button:not(.is-style-button-underline) a:focus,
+.wp-block-button:not(.is-style-button-underline, .is-style-arrow) a:hover, .wp-block-button:not(.is-style-button-underline, .is-style-arrow) a:focus,
 button:hover,input[type="button"]:hover,input[type="reset"]:hover,input[type="submit"]:hover {
 	box-shadow: 4px 4px 0 var(--button-shadow-hover);
 	color: var(--button-color-hover);
@@ -1956,7 +1956,7 @@ input[type="text"]:focus,input[type="password"]:focus,input[type="email"]:focus,
 	background:var(--input-bg-focus)
 }
 
-.wp-block-button:not(.is-style-button-underline) a,
+.wp-block-button:not(.is-style-button-underline, .is-style-arrow) a,
 input[type="submit"],button,.button {
 	background:var(--button-bg);
 	color:var(--button-color);
@@ -1966,10 +1966,41 @@ input[type="submit"],button,.button {
 	padding:12px 24px
 }
 
-.wp-block-button:not(.is-style-button-underline) a:hover, .wp-block-button:not(.is-style-button-underline) a:focus,
+.wp-block-button:not(.is-style-button-underline, .is-style-arrow) a:hover, .wp-block-button:not(.is-style-button-underline, .is-style-arrow) a:focus,
 input[type="submit"]:hover,input[type="submit"]:focus,button:hover,button:focus,.button:hover,.button:focus {
 	background:var(--button-bg-hover);
 	color:var(--button-color-hover);
+}
+
+.wp-block-button.is-style-arrow .wp-block-button__link {
+	font-size: max(1rem, 0.5em);
+	font-weight: 400;
+	text-align: left;
+	line-height: 1.1;
+	padding: 1.5em;
+	padding-right: 6rem;
+	position: relative;
+}
+
+.wp-block-button.is-style-arrow .wp-block-button__link:after {
+	content: "\f061";
+	font-family: "Font Awesome 6 Free";
+	font-style: 'normal';
+	font-weight: 900;
+	font-size: max(2rem, 2em);
+	position: absolute;
+	right: 1rem;
+	top: 0;
+	height: 100%;
+	display: flex;
+	align-items: center;
+	box-sizing: border-box;
+}
+
+.wp-block-button.is-style-arrow .wp-block-button__link strong {
+	font-size: max(2rem, 2em);
+	font-weight: 700;
+	display: block;
 }
 
 #primary .alignwide .blocks-gallery-grid {


### PR DESCRIPTION
Fixes #38 

Adds an arrow button style. Uses min and max to ensure sizes remain accessible, e.g the font size of the small text will not be smaller than 1rem.

To make the text stack, use "bold" on the large, bold text.