### PR TITLE
update contrast styles and remove inverted styles logic

### DIFF
--- a/src/wp-a11y-day/css/high-contrast-dark.css
+++ b/src/wp-a11y-day/css/high-contrast-dark.css
@@ -5,18 +5,4 @@
 body {
 	--bg: Black;
 	--fg: White;
-	--accent1: DarkBlue;
-	--accent1s1: Blue;
-	--accent1s2: Aqua;
-	--accent2: Green;
-	--accent2s1: LimeGreen;
-	--accent3: Orange;
-	--accent3s1: Gold;
-	--accent4: Yellow;
-	--accent4s1: LightYellow;
-	--accent5: Coral;
-	--accent6: Magenta;
-	--s1: #333;
-	--s2: #666;
-	--s3: #ccc;
 }

--- a/src/wp-a11y-day/css/high-contrast.css
+++ b/src/wp-a11y-day/css/high-contrast.css
@@ -5,18 +5,4 @@
 body {
 	--bg: White;
 	--fg: Black;
-	--accent1: Aqua;
-	--accent1s1: Blue;
-	--accent1s2: DarkBlue;
-	--accent2: LimeGreen;
-	--accent2s1: Green;
-	--accent3: Gold;
-	--accent3s1: DarkOrange;
-	--accent4: LightYellow;
-	--accent4s1: Yellow;
-	--accent5: Magenta;
-	--accent6: Coral;
-	--s1: #ccc;
-	--s2: #666;
-	--s3: #333;
 }

--- a/src/wp-a11y-day/js/color-scheme.js
+++ b/src/wp-a11y-day/js/color-scheme.js
@@ -63,16 +63,6 @@ document.addEventListener( 'DOMContentLoaded', () => {
 	}
 
 	/**
-	 * Checks if the user is has Inverted Colors on.
-	 *
-	 * @returns {Boolean}
-	 */
-	const isUsingMacInvertedColors = () => {
-		const mediaQueryList = window.matchMedia('(inverted-colors: inverted)');
-		return mediaQueryList.matches;
-	}
-
-	/**
 	 * Checks if the user requested high contrast.
 	 *
 	 * @returns {Boolean}
@@ -109,10 +99,11 @@ document.addEventListener( 'DOMContentLoaded', () => {
 	if ('dark' === colorschemeCookie || (! colorschemeCookie && prefersDarkScheme)) {
 		toggleButton(darkModeButton, lightModeButton);
 		toggleStyle();
-		highContrastStyleSheet.setAttribute('href', isUsingMacInvertedColors ? wpA11YdayColorScheme.hcstylesheet : wpA11YdayColorScheme.hcdarkstylesheet );
+		
+		highContrastStyleSheet.setAttribute('href', wpA11YdayColorScheme.hcdarkstylesheet );
 	}
 
-	if (isUsingMacInvertedColors() || isHighContrast()) {
+	if (isHighContrast()) {
 		head.appendChild(highContrastStyleSheet);
 	}
 
@@ -123,7 +114,7 @@ document.addEventListener( 'DOMContentLoaded', () => {
 			toggleButton(lightModeButton, darkModeButton);
 			toggleStyle('remove');
 			setCookie(colorSchemeCookieName, 'light');
-			highContrastStyleSheet.setAttribute('href', isUsingMacInvertedColors ? wpA11YdayColorScheme.hcdarkstylesheet : wpA11YdayColorScheme.hcstylesheet );
+			highContrastStyleSheet.setAttribute('href', wpA11YdayColorScheme.hcstylesheet );
 		}
 	});
 
@@ -134,7 +125,7 @@ document.addEventListener( 'DOMContentLoaded', () => {
 			toggleButton(darkModeButton, lightModeButton);
 			toggleStyle();
 			setCookie(colorSchemeCookieName, 'dark');
-			highContrastStyleSheet.setAttribute('href', isUsingMacInvertedColors ? wpA11YdayColorScheme.hcstylesheet : wpA11YdayColorScheme.hcdarkstylesheet );
+			highContrastStyleSheet.setAttribute('href', wpA11YdayColorScheme.hcdarkstylesheet );
 		}
 	});
 });


### PR DESCRIPTION
@joedolson I did testing with the current styles and everything is 7:1 or better, just using solid black and solid white background/foreground with existing styles so I simplified the high contrast. I also did testing with the inverted colors and TBH it was better to nix that feature and call it a day because no adjustments were needed to maintain the best contrast.