### PR TITLE
add background to sponsors in darkmode

### DIFF
--- a/src/wp-a11y-day/css/dark-mode.css
+++ b/src/wp-a11y-day/css/dark-mode.css
@@ -189,3 +189,7 @@ h3 {
 .single-wpcsp_sponsor .wpcsp-sponsor-swag h2 {
     color: var(--accent4s1);
 }
+
+.wpcsp-sponsor-description a {
+	background-color: var(--fg);
+}

--- a/src/wp-a11y-day/style.css
+++ b/src/wp-a11y-day/style.css
@@ -2210,6 +2210,10 @@ input[type="submit"]:hover,input[type="submit"]:focus,button:hover,button:focus,
 	border: 4px solid var(--sponsorship-microsponsors-border-color);
 }
 
+.wpcsp-sponsors .wpcsp-sponsor-level .wpcsp-sponsor-level-heading span {
+	background-color: transparent;
+}
+
 .wpcsp-sponsor-description a {
 	padding: 8px;
 }

--- a/src/wp-a11y-day/style.css
+++ b/src/wp-a11y-day/style.css
@@ -2210,6 +2210,10 @@ input[type="submit"]:hover,input[type="submit"]:focus,button:hover,button:focus,
 	border: 4px solid var(--sponsorship-microsponsors-border-color);
 }
 
+.wpcsp-sponsor-description a {
+	padding: 8px;
+}
+
 .gv-grid-col-2-3 {
 	width:100%
 }


### PR DESCRIPTION
Fixes #68 

This adds some padding to the sponsors in all modes so there is no layout shift when switching to dark mode and then a white BG when in dark mode to improve the appearance of the images.

I tested with just some BG on the image and it worked but looked off.
![screencapture-2023-wpaccessibility-day-sponsors-2023-08-19-10_51_24](https://github.com/wpa11yday/wpaccessibilityday/assets/835568/f16aaca5-01aa-4bc7-bb3e-c76134184460)
