### PR TITLE
optionally load front end styles in editor

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -34,6 +34,10 @@ if ( ! function_exists( 'wp_accessibility_day_setup' ) ) :
 		add_theme_support( 'editor-styles' );
 		add_editor_style( 'style-editor.css' );
 
+		if ( ! get_user_meta( get_current_user_id(), 'disable_front_end_styles', true ) ) {
+			add_editor_style( 'style.css' );
+		}
+
 		// Support responsive embedding.
 		add_theme_support( 'responsive-embeds' );
 


### PR DESCRIPTION
This is the first pass to get front-end styles in the editor. Since this doesn't have a build process, the entire front-end stylesheet is being loaded. This should receive some testing to make sure that nothing is broken. I did test this locally but am not as familiar with how the editor is being used IRL on the site so additional testing is recommended.

It may make sense to add a build process and split the stylesheet into components so that only the required components are loaded.

Addresses: https://github.com/wpa11yday/wpaccessibilityday/issues/88
