### PR TITLE
Vertically center items in the nav menu

### DIFF
--- a/style.css
+++ b/style.css
@@ -1894,7 +1894,9 @@ h2.event-time {
 }
 
 .navigation .menu li {
-	list-style-type:none
+	list-style-type:none;
+	display:flex;
+	align-items:center;
 }
 
 .navigation .menu > li {


### PR DESCRIPTION
I want to add the .wp-block-button class to the "Register to Attend" menu item, but without this change, the other items in the nav are aligned vertically. 

Before code change:
<img width="868" alt="Screenshot 2024-08-13 at 11 02 40 PM" src="https://github.com/user-attachments/assets/576ddba3-8fbd-45e6-8e42-4a555a6980a6">

After:
<img width="841" alt="Screenshot 2024-08-13 at 11 03 23 PM" src="https://github.com/user-attachments/assets/1036f8aa-0daf-4d1c-bb57-88e754b36131">
